### PR TITLE
Use Forge deploy flow for watcher tests and local dev

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,7 +21,7 @@ deploy-local:
             "$POLYPLACE_RPC_URL"; then break; fi
         sleep 0.2
     done
-    OUTPUT=$(uv run python -m polyplace_watcher.forge_deploy \
+    OUTPUT=$(uv run python -m tools.forge_deploy \
         --rpc-url "$POLYPLACE_RPC_URL" \
         --private-key "$POLYPLACE_PRIVATE_KEY" \
         --manifest-path "$MANIFEST_PATH" \

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,7 @@ deploy-local:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p .local
+    MANIFEST_PATH="$PWD/.local/deployment.json"
     export POLYPLACE_RPC_URL=http://127.0.0.1:8545
     export POLYPLACE_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     for _ in $(seq 1 30); do
@@ -20,8 +21,12 @@ deploy-local:
             "$POLYPLACE_RPC_URL"; then break; fi
         sleep 0.2
     done
-    OUTPUT=$(uv run polyplace-dev deploy --cooldown=30)
-    eval "$(echo "$OUTPUT" | python3 -c 'import json, sys; d = json.load(sys.stdin); [print(f"{k.upper()}_ADDRESS={v}") for k, v in d.items()]')"
+    OUTPUT=$(uv run python -m polyplace_watcher.forge_deploy \
+        --rpc-url "$POLYPLACE_RPC_URL" \
+        --private-key "$POLYPLACE_PRIVATE_KEY" \
+        --manifest-path "$MANIFEST_PATH" \
+        --cooldown 30)
+    eval "$(echo "$OUTPUT" | python3 -c 'import json, sys; d = json.load(sys.stdin); [print(f"{k.upper()}_ADDRESS={d[k]}") for k in ("grid", "token", "faucet")]')"
     cat > .local/watcher.env <<EOF
     WEB3_HTTP_URL=http://anvil:8545
     WEB3_WS_URL=ws://anvil:8545

--- a/README.md
+++ b/README.md
@@ -31,12 +31,19 @@ just deploy-local
 just watcher
 ```
 
-`just deploy-local` deploys contracts to the host Anvil endpoint
-`http://127.0.0.1:8545` and writes `.local/watcher.env`. The watcher container
-uses that file as a Compose env override when it exists, and connects to Anvil
-through the Compose service name: `http://anvil:8545` and `ws://anvil:8545`.
+`just deploy-local` shells out to the sibling
+[`polyplace-contracts`](../polyplace-contracts) repo and runs the Forge deploy
+script against the host Anvil endpoint `http://127.0.0.1:8545`. It writes the
+Forge deployment manifest to `.local/deployment.json` and derives
+`.local/watcher.env` from it. The watcher container uses that file as a Compose
+env override when it exists, and connects to Anvil through the Compose service
+name: `http://anvil:8545` and `ws://anvil:8545`.
 
-The generated `.local/watcher.env` is local runtime state and is ignored by git.
+If the contracts repo is not present as a sibling, set
+`POLYPLACE_CONTRACTS_REPO` to its repo root before running `just deploy-local`.
+
+The generated `.local/deployment.json` and `.local/watcher.env` are local
+runtime state and are ignored by git.
 
 ## Logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,4 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+pythonpath = ["."]

--- a/src/polyplace_watcher/app.py
+++ b/src/polyplace_watcher/app.py
@@ -9,7 +9,7 @@ from typing import AsyncGenerator
 from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
-from polyplace_contracts.deploy import Deployment
+from polyplace_watcher.config import WatcherConfig
 from polyplace_watcher.grid_store import GridStore
 from polyplace_watcher.observability import configure_logging
 from polyplace_watcher.watcher import Watcher
@@ -18,15 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 def _watcher_from_env(store: GridStore) -> Watcher:
-    http_url = os.environ["WEB3_HTTP_URL"]
-    ws_url = os.environ["WEB3_WS_URL"]
-    start_block = int(os.environ["START_BLOCK"])
-    deployment = Deployment(
-        grid=os.environ["GRID_ADDRESS"],
-        token=os.environ["TOKEN_ADDRESS"],
-        faucet=os.environ["FAUCET_ADDRESS"],
+    config = WatcherConfig.from_env()
+    return Watcher(
+        http_url=config.http_url,
+        ws_url=config.ws_url,
+        contracts=config.contracts,
+        start_block=config.start_block,
+        store=store,
     )
-    return Watcher(http_url=http_url, ws_url=ws_url, deployment=deployment, start_block=start_block, store=store)
 
 
 async def _snapshot_loop(store: GridStore, path: Path, interval: int) -> None:

--- a/src/polyplace_watcher/config.py
+++ b/src/polyplace_watcher/config.py
@@ -4,6 +4,13 @@ import os
 from dataclasses import dataclass
 
 
+def _require(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return value
+
+
 @dataclass(frozen=True)
 class ContractsConfig:
     token: str
@@ -13,9 +20,9 @@ class ContractsConfig:
     @classmethod
     def from_env(cls) -> "ContractsConfig":
         return cls(
-            token=os.environ["TOKEN_ADDRESS"],
-            faucet=os.environ["FAUCET_ADDRESS"],
-            grid=os.environ["GRID_ADDRESS"],
+            token=_require("TOKEN_ADDRESS"),
+            faucet=_require("FAUCET_ADDRESS"),
+            grid=_require("GRID_ADDRESS"),
         )
 
 
@@ -29,8 +36,8 @@ class WatcherConfig:
     @classmethod
     def from_env(cls) -> "WatcherConfig":
         return cls(
-            http_url=os.environ["WEB3_HTTP_URL"],
-            ws_url=os.environ["WEB3_WS_URL"],
-            start_block=int(os.environ["START_BLOCK"]),
+            http_url=_require("WEB3_HTTP_URL"),
+            ws_url=_require("WEB3_WS_URL"),
+            start_block=int(_require("START_BLOCK")),
             contracts=ContractsConfig.from_env(),
         )

--- a/src/polyplace_watcher/config.py
+++ b/src/polyplace_watcher/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ContractsConfig:
+    token: str
+    faucet: str
+    grid: str
+
+    @classmethod
+    def from_env(cls) -> "ContractsConfig":
+        return cls(
+            token=os.environ["TOKEN_ADDRESS"],
+            faucet=os.environ["FAUCET_ADDRESS"],
+            grid=os.environ["GRID_ADDRESS"],
+        )
+
+
+@dataclass(frozen=True)
+class WatcherConfig:
+    http_url: str
+    ws_url: str
+    start_block: int
+    contracts: ContractsConfig
+
+    @classmethod
+    def from_env(cls) -> "WatcherConfig":
+        return cls(
+            http_url=os.environ["WEB3_HTTP_URL"],
+            ws_url=os.environ["WEB3_WS_URL"],
+            start_block=int(os.environ["START_BLOCK"]),
+            contracts=ContractsConfig.from_env(),
+        )

--- a/src/polyplace_watcher/forge_deploy.py
+++ b/src/polyplace_watcher/forge_deploy.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from polyplace_contracts.deploy import Deployment
+
+
+@dataclass
+class ForgeDeployment(Deployment):
+    chain_id: int
+    deployer: str
+    initial_supply: int
+    claim_amount: int
+    cooldown: int
+    rent_price: int
+    rent_duration: int
+
+
+def contracts_repo_root() -> Path:
+    override = os.environ.get("POLYPLACE_CONTRACTS_REPO")
+    if override:
+        root = Path(override).expanduser().resolve()
+    else:
+        root = Path(__file__).resolve().parents[3] / "polyplace-contracts"
+
+    if not root.is_dir():
+        raise RuntimeError(
+            "Cannot find sibling polyplace-contracts repo. "
+            "Set POLYPLACE_CONTRACTS_REPO to the repo root if it lives elsewhere."
+        )
+
+    return root
+
+
+def load_forge_deployment(path: str | Path) -> ForgeDeployment:
+    data = json.loads(Path(path).read_text())
+    return ForgeDeployment(
+        token=data["token"],
+        faucet=data["faucet"],
+        grid=data["grid"],
+        chain_id=int(data["chainId"]),
+        deployer=data["deployer"],
+        initial_supply=int(data["initialSupply"]),
+        claim_amount=int(data["claimAmount"]),
+        cooldown=int(data["cooldown"]),
+        rent_price=int(data["rentPrice"]),
+        rent_duration=int(data["rentDuration"]),
+    )
+
+
+def deploy_via_forge(
+    *,
+    rpc_url: str,
+    private_key: str,
+    manifest_path: str | Path,
+    claim_amount: int | None = None,
+    cooldown: int | None = None,
+    rent_price: int | None = None,
+    rent_duration: int | None = None,
+    repo_root: str | Path | None = None,
+) -> ForgeDeployment:
+    contracts_root = Path(repo_root).resolve() if repo_root is not None else contracts_repo_root()
+    output_path = Path(manifest_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    forge_output_dir = contracts_root / ".forge-manifests"
+    forge_output_dir.mkdir(parents=True, exist_ok=True)
+    forge_output_path = forge_output_dir / f"{output_path.stem}-{uuid4().hex}.json"
+
+    env = os.environ.copy()
+    env["PRIVATE_KEY"] = private_key
+    env["POLYPLACE_DEPLOYMENT_MANIFEST_PATH"] = str(forge_output_path)
+    if claim_amount is not None:
+        env["POLYPLACE_DEPLOY_CLAIM_AMOUNT"] = str(claim_amount)
+    if cooldown is not None:
+        env["POLYPLACE_DEPLOY_COOLDOWN"] = str(cooldown)
+    if rent_price is not None:
+        env["POLYPLACE_DEPLOY_RENT_PRICE"] = str(rent_price)
+    if rent_duration is not None:
+        env["POLYPLACE_DEPLOY_RENT_DURATION"] = str(rent_duration)
+
+    cmd = [
+        "forge",
+        "script",
+        "script/Deploy.s.sol",
+        "--rpc-url",
+        rpc_url,
+        "--broadcast",
+        "--slow",
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=contracts_root,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Forge deploy failed.\n"
+            f"cwd: {contracts_root}\n"
+            f"command: {' '.join(cmd)}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+
+    if not forge_output_path.is_file():
+        raise RuntimeError(f"Forge deploy did not write manifest: {forge_output_path}")
+
+    output_path.write_text(forge_output_path.read_text())
+
+    return load_forge_deployment(output_path)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deploy Polyplace contracts with Forge and print the manifest JSON.")
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--private-key", required=True)
+    parser.add_argument("--manifest-path", required=True)
+    parser.add_argument("--contracts-repo")
+    parser.add_argument("--claim-amount", type=int)
+    parser.add_argument("--cooldown", type=int)
+    parser.add_argument("--rent-price", type=int)
+    parser.add_argument("--rent-duration", type=int)
+    return parser.parse_args()
+
+
+def _json_for_stdout(deployment: ForgeDeployment) -> dict[str, Any]:
+    return {
+        "token": deployment.token,
+        "faucet": deployment.faucet,
+        "grid": deployment.grid,
+        "chainId": deployment.chain_id,
+        "deployer": deployment.deployer,
+        "initialSupply": str(deployment.initial_supply),
+        "claimAmount": str(deployment.claim_amount),
+        "cooldown": deployment.cooldown,
+        "rentPrice": str(deployment.rent_price),
+        "rentDuration": deployment.rent_duration,
+    }
+
+
+def main() -> None:
+    args = _parse_args()
+    deployment = deploy_via_forge(
+        rpc_url=args.rpc_url,
+        private_key=args.private_key,
+        manifest_path=args.manifest_path,
+        claim_amount=args.claim_amount,
+        cooldown=args.cooldown,
+        rent_price=args.rent_price,
+        rent_duration=args.rent_duration,
+        repo_root=args.contracts_repo,
+    )
+    print(json.dumps(_json_for_stdout(deployment)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/polyplace_watcher/watcher.py
+++ b/src/polyplace_watcher/watcher.py
@@ -7,7 +7,7 @@ from web3.types import LogReceipt
 from websockets.exceptions import ConnectionClosed
 
 from polyplace_contracts import PLACE_GRID_ABI
-from polyplace_contracts.deploy import Deployment
+from polyplace_watcher.config import ContractsConfig
 
 from polyplace_watcher.events import CellColorUpdated, CellRented
 from polyplace_watcher.grid_store import GridStore
@@ -31,15 +31,15 @@ class Watcher:
         self,
         http_url: str,
         ws_url: str,
-        deployment: Deployment,
+        contracts: ContractsConfig,
         start_block: int = 0,
         store: GridStore | None = None,
     ) -> None:
         self.store = store if store is not None else GridStore()
         self._w3 = Web3(Web3.HTTPProvider(http_url))
         self._ws_url = ws_url
-        self._contract = self._w3.eth.contract(address=deployment.grid, abi=PLACE_GRID_ABI)
-        self._deployment = deployment
+        self._contract = self._w3.eth.contract(address=contracts.grid, abi=PLACE_GRID_ABI)
+        self._contracts = contracts
         self._start_block: int = start_block
         self._ws_w3: AsyncWeb3 | None = None
         logger.info(
@@ -49,9 +49,9 @@ class Watcher:
                 "config": {
                     "WEB3_HTTP_URL": scrub_url(http_url),
                     "WEB3_WS_URL": scrub_url(ws_url),
-                    "GRID_ADDRESS": deployment.grid,
-                    "TOKEN_ADDRESS": deployment.token,
-                    "FAUCET_ADDRESS": deployment.faucet,
+                    "GRID_ADDRESS": contracts.grid,
+                    "TOKEN_ADDRESS": contracts.token,
+                    "FAUCET_ADDRESS": contracts.faucet,
                     "START_BLOCK": start_block,
                 },
             },
@@ -77,7 +77,7 @@ class Watcher:
             },
         )
         logs = self._w3.eth.get_logs({
-            "address": self._deployment.grid,
+            "address": self._contracts.grid,
             "fromBlock": from_block,
             "toBlock": "latest",
             "topics": [[_CELL_RENTED_TOPIC, _CELL_COLOR_UPDATED_TOPIC]],
@@ -120,7 +120,7 @@ class Watcher:
                         },
                     )
                     await w3.eth.subscribe("logs", {
-                        "address": self._deployment.grid,
+                        "address": self._contracts.grid,
                         "topics": [[_CELL_RENTED_TOPIC, _CELL_COLOR_UPDATED_TOPIC]],
                     })
                     logger.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from eth_account import Account
 from web3 import Web3
 from web3.types import TxReceipt
 
-from polyplace_watcher.forge_deploy import ForgeDeployment, deploy_via_forge
+from tools.forge_deploy import ForgeDeployment, deploy_via_forge
 
 # First default anvil account private key
 _DEPLOYER_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import subprocess
 import time
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import pytest
 from eth_account import Account
 from web3 import Web3
 from web3.types import TxReceipt
 
-from polyplace_contracts import deploy
-from polyplace_contracts.deploy import Deployment
+from polyplace_watcher.forge_deploy import ForgeDeployment, deploy_via_forge
 
 # First default anvil account private key
 _DEPLOYER_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -24,6 +24,19 @@ def send_tx(w3: Web3, fn, key: str) -> TxReceipt:
     signed = account.sign_transaction(tx)
     tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
     return w3.eth.wait_for_transaction_receipt(tx_hash)
+
+
+def _rpc(w3: Web3, method: str, params: list[object]) -> object:
+    response = w3.provider.make_request(method, params)  # type: ignore[attr-defined]
+    if "error" in response:
+        raise RuntimeError(f"{method} failed: {response['error']}")
+    return response["result"]
+
+
+@dataclass
+class _DeploymentState:
+    deployment: ForgeDeployment
+    snapshot_id: object
 
 
 @pytest.fixture(scope="session")
@@ -58,7 +71,23 @@ def w3() -> Iterator[Web3]:
         proc.wait()
 
 
+@pytest.fixture(scope="session")
+def _deployment_state(w3: Web3, tmp_path_factory: pytest.TempPathFactory) -> _DeploymentState:
+    _rpc(w3, "anvil_reset", [])
+    manifest_path = tmp_path_factory.mktemp("forge-deploy") / "deployment.json"
+    deployment = deploy_via_forge(
+        rpc_url=_ANVIL_URL,
+        private_key=_DEPLOYER_KEY,
+        manifest_path=manifest_path,
+    )
+    snapshot_id = _rpc(w3, "anvil_snapshot", [])
+    return _DeploymentState(deployment=deployment, snapshot_id=snapshot_id)
+
+
 @pytest.fixture
-def deployed_contracts(w3: Web3) -> Deployment:
-    w3.provider.make_request("anvil_reset", [])  # type: ignore[attr-defined]
-    return deploy(w3, _DEPLOYER_KEY)
+def deployed_contracts(w3: Web3, _deployment_state: _DeploymentState) -> ForgeDeployment:
+    reverted = _rpc(w3, "anvil_revert", [_deployment_state.snapshot_id])
+    if reverted is not True:
+        raise RuntimeError(f"anvil_revert returned {reverted!r}")
+    _deployment_state.snapshot_id = _rpc(w3, "anvil_snapshot", [])
+    return _deployment_state.deployment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,8 @@ def _rpc(w3: Web3, method: str, params: list[object]) -> object:
 @dataclass
 class _DeploymentState:
     deployment: ForgeDeployment
+    # Each anvil_revert consumes the snapshot it reverts to, so tests must
+    # immediately take and store a fresh snapshot for the next test.
     snapshot_id: object
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -5,7 +5,7 @@ from polyplace_contracts import (
     PLACE_GRID_ABI,
     PLACE_TOKEN_ABI,
 )
-from polyplace_watcher.forge_deploy import ForgeDeployment
+from tools.forge_deploy import ForgeDeployment
 
 
 def test_token_metadata(w3: Web3, deployed_contracts: ForgeDeployment) -> None:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -5,34 +5,27 @@ from polyplace_contracts import (
     PLACE_GRID_ABI,
     PLACE_TOKEN_ABI,
 )
-from polyplace_contracts.deploy import (
-    DEPLOY_CLAIM_AMOUNT,
-    DEPLOY_COOLDOWN,
-    DEPLOY_RENT_DURATION,
-    DEPLOY_RENT_PRICE,
-    INITIAL_SUPPLY,
-    Deployment,
-)
+from polyplace_watcher.forge_deploy import ForgeDeployment
 
 
-def test_token_metadata(w3: Web3, deployed_contracts: Deployment) -> None:
+def test_token_metadata(w3: Web3, deployed_contracts: ForgeDeployment) -> None:
     token = w3.eth.contract(address=deployed_contracts.token, abi=PLACE_TOKEN_ABI)
     assert token.functions.name().call() == "Place"
     assert token.functions.symbol().call() == "PLACE"
     assert token.functions.decimals().call() == 18
-    assert token.functions.totalSupply().call() == INITIAL_SUPPLY
+    assert token.functions.totalSupply().call() == deployed_contracts.initial_supply
 
 
-def test_faucet_config(w3: Web3, deployed_contracts: Deployment) -> None:
+def test_faucet_config(w3: Web3, deployed_contracts: ForgeDeployment) -> None:
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
     assert faucet.functions.TOKEN().call() == deployed_contracts.token
-    assert faucet.functions.claimAmount().call() == DEPLOY_CLAIM_AMOUNT
-    assert faucet.functions.cooldown().call() == DEPLOY_COOLDOWN
+    assert faucet.functions.claimAmount().call() == deployed_contracts.claim_amount
+    assert faucet.functions.cooldown().call() == deployed_contracts.cooldown
 
 
-def test_grid_config(w3: Web3, deployed_contracts: Deployment) -> None:
+def test_grid_config(w3: Web3, deployed_contracts: ForgeDeployment) -> None:
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
     assert grid.functions.TOKEN().call() == deployed_contracts.token
     assert grid.functions.FAUCET().call() == deployed_contracts.faucet
-    assert grid.functions.rentPrice().call() == DEPLOY_RENT_PRICE
-    assert grid.functions.rentDuration().call() == DEPLOY_RENT_DURATION
+    assert grid.functions.rentPrice().call() == deployed_contracts.rent_price
+    assert grid.functions.rentDuration().call() == deployed_contracts.rent_duration

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5,9 +5,9 @@ from httpx import ASGITransport, AsyncClient
 from web3 import Web3
 
 from polyplace_contracts import PLACE_FAUCET_ABI, PLACE_GRID_ABI, PLACE_TOKEN_ABI
-from polyplace_contracts.deploy import DEPLOY_RENT_PRICE, Deployment
 from polyplace_watcher.app import app, lifespan
 from polyplace_watcher.events import RGB
+from polyplace_watcher.forge_deploy import ForgeDeployment
 from polyplace_watcher.grid import Grid
 
 from conftest import _DEPLOYER_KEY, send_tx
@@ -28,7 +28,7 @@ async def test_e2e_grid_endpoint(
     w3: Web3,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
     tmp_path,
 ) -> None:
     monkeypatch.setenv("WEB3_HTTP_URL", http_url)
@@ -45,7 +45,7 @@ async def test_e2e_grid_endpoint(
     grid_contract = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE * 2), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price * 2), _DEPLOYER_KEY)
 
     async with lifespan(app):
         store = app.state.store

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ from web3 import Web3
 from polyplace_contracts import PLACE_FAUCET_ABI, PLACE_GRID_ABI, PLACE_TOKEN_ABI
 from polyplace_watcher.app import app, lifespan
 from polyplace_watcher.events import RGB
-from polyplace_watcher.forge_deploy import ForgeDeployment
+from tools.forge_deploy import ForgeDeployment
 from polyplace_watcher.grid import Grid
 
 from conftest import _DEPLOYER_KEY, send_tx

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -8,7 +8,7 @@ from web3 import Web3
 
 from polyplace_contracts import PLACE_FAUCET_ABI, PLACE_GRID_ABI, PLACE_TOKEN_ABI
 from polyplace_watcher.events import CellColorUpdated, RGB
-from polyplace_watcher.forge_deploy import ForgeDeployment
+from tools.forge_deploy import ForgeDeployment
 import polyplace_watcher.watcher as watcher_module
 from polyplace_watcher.watcher import Watcher
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -7,25 +7,25 @@ from eth_account import Account
 from web3 import Web3
 
 from polyplace_contracts import PLACE_FAUCET_ABI, PLACE_GRID_ABI, PLACE_TOKEN_ABI
-from polyplace_contracts.deploy import DEPLOY_RENT_PRICE, Deployment
 from polyplace_watcher.events import CellColorUpdated, RGB
+from polyplace_watcher.forge_deploy import ForgeDeployment
 import polyplace_watcher.watcher as watcher_module
 from polyplace_watcher.watcher import Watcher
 
 from conftest import _DEPLOYER_KEY, send_tx
 
 
-def test_watcher_instantiation(http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_watcher_instantiation(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     assert watcher.store is not None
 
 
-def test_watcher_store_initially_empty(http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_watcher_store_initially_empty(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     assert watcher.store.get(0) is None
 
 
-def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     caller = Account.from_key(_DEPLOYER_KEY)
 
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
@@ -33,7 +33,7 @@ def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deploy
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price), _DEPLOYER_KEY)
 
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(5, 10, 0xFF8800), _DEPLOYER_KEY)
@@ -49,7 +49,7 @@ def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deploy
     assert cell.color == RGB(r=255, g=136, b=0)
 
 
-def test_fetch_logs_empty_range_leaves_store_empty(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_fetch_logs_empty_range_leaves_store_empty(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     from_block = w3.eth.block_number
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     for event, block, log_index in watcher.fetch_logs(from_block):
@@ -57,13 +57,13 @@ def test_fetch_logs_empty_range_leaves_store_empty(w3: Web3, http_url: str, ws_u
     assert watcher.store.get(0) is None
 
 
-def test_fetch_logs_sets_last_block(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_fetch_logs_sets_last_block(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
     token = w3.eth.contract(address=deployed_contracts.token, abi=PLACE_TOKEN_ABI)
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price), _DEPLOYER_KEY)
 
     from_block = w3.eth.block_number
     receipt = send_tx(w3, grid.functions.rentCell(1, 1, 0xFF0000), _DEPLOYER_KEY)
@@ -75,7 +75,7 @@ def test_fetch_logs_sets_last_block(w3: Web3, http_url: str, ws_url: str, deploy
     assert watcher.store.last_block == receipt["blockNumber"]
 
 
-def test_fetch_logs_empty_does_not_change_last_block(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+def test_fetch_logs_empty_does_not_change_last_block(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     watcher.store._last_block = 5
     for event, block, log_index in watcher.fetch_logs(w3.eth.block_number):
@@ -83,13 +83,13 @@ def test_fetch_logs_empty_does_not_change_last_block(w3: Web3, http_url: str, ws
     assert watcher.store.last_block == 5
 
 
-async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment, tmp_path: Path) -> None:
+async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment, tmp_path: Path) -> None:
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
     token = w3.eth.contract(address=deployed_contracts.token, abi=PLACE_TOKEN_ABI)
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price), _DEPLOYER_KEY)
 
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(3, 4, 0x112233), _DEPLOYER_KEY)
@@ -111,7 +111,7 @@ async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deploye
     assert watcher2.store.get(cell_id) == watcher.store.get(cell_id)
 
 
-async def test_save_snapshot_raises_without_last_block(http_url: str, ws_url: str, deployed_contracts: Deployment, tmp_path: Path) -> None:
+async def test_save_snapshot_raises_without_last_block(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment, tmp_path: Path) -> None:
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     with pytest.raises(ValueError):
         await watcher.store.save_snapshot(tmp_path / "snap.json")
@@ -121,7 +121,7 @@ async def test_watch_catches_up_from_loaded_snapshot(
     w3: Web3,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
     tmp_path: Path,
 ) -> None:
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
@@ -129,7 +129,7 @@ async def test_watch_catches_up_from_loaded_snapshot(
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE * 3), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price * 3), _DEPLOYER_KEY)
 
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(1, 1, 0xFF0000), _DEPLOYER_KEY)
@@ -176,7 +176,7 @@ async def test_watch_catches_up_from_loaded_snapshot(
             await watch_task
 
 
-async def test_watch_reconnects_after_disconnect(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+async def test_watch_reconnects_after_disconnect(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     caller = Account.from_key(_DEPLOYER_KEY)
 
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
@@ -184,7 +184,7 @@ async def test_watch_reconnects_after_disconnect(w3: Web3, http_url: str, ws_url
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE * 2), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price * 2), _DEPLOYER_KEY)
 
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     watch_task = asyncio.create_task(watcher.watch())
@@ -225,7 +225,7 @@ async def test_watch_resubscribes_before_reconnect_backfill(
     monkeypatch: pytest.MonkeyPatch,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
 ) -> None:
     state = {
         "connection_count": 0,
@@ -298,7 +298,7 @@ async def test_watch_backfills_from_start_block_on_cold_start(
     monkeypatch: pytest.MonkeyPatch,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
 ) -> None:
     state: dict[str, object] = {"backfill_from_block": None}
 
@@ -352,7 +352,7 @@ async def test_watch_backfills_from_last_block_on_reconnect(
     monkeypatch: pytest.MonkeyPatch,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
 ) -> None:
     state: dict[str, object] = {"backfill_from_block": None}
 
@@ -407,7 +407,7 @@ async def test_watch_fetch_logs_called_via_to_thread(
     monkeypatch: pytest.MonkeyPatch,
     http_url: str,
     ws_url: str,
-    deployed_contracts: Deployment,
+    deployed_contracts: ForgeDeployment,
 ) -> None:
     to_thread_calls: list[object] = []
 
@@ -461,7 +461,7 @@ async def test_watch_fetch_logs_called_via_to_thread(
     assert fake_fetch_logs in to_thread_calls
 
 
-async def test_watch_populates_store(w3: Web3, http_url: str, ws_url: str, deployed_contracts: Deployment) -> None:
+async def test_watch_populates_store(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     caller = Account.from_key(_DEPLOYER_KEY)
 
     faucet = w3.eth.contract(address=deployed_contracts.faucet, abi=PLACE_FAUCET_ABI)
@@ -469,7 +469,7 @@ async def test_watch_populates_store(w3: Web3, http_url: str, ws_url: str, deplo
     grid = w3.eth.contract(address=deployed_contracts.grid, abi=PLACE_GRID_ABI)
 
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
-    send_tx(w3, token.functions.approve(deployed_contracts.grid, DEPLOY_RENT_PRICE), _DEPLOYER_KEY)
+    send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price), _DEPLOYER_KEY)
 
     watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
     watch_task = asyncio.create_task(watcher.watch())

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -16,12 +16,12 @@ from conftest import _DEPLOYER_KEY, send_tx
 
 
 def test_watcher_instantiation(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     assert watcher.store is not None
 
 
 def test_watcher_store_initially_empty(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     assert watcher.store.get(0) is None
 
 
@@ -38,7 +38,7 @@ def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deploy
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(5, 10, 0xFF8800), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     for event, block, log_index in watcher.fetch_logs(from_block):
         watcher.store.apply(event, block, log_index)
 
@@ -51,7 +51,7 @@ def test_fetch_logs_populates_store(w3: Web3, http_url: str, ws_url: str, deploy
 
 def test_fetch_logs_empty_range_leaves_store_empty(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
     from_block = w3.eth.block_number
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     for event, block, log_index in watcher.fetch_logs(from_block):
         watcher.store.apply(event, block, log_index)
     assert watcher.store.get(0) is None
@@ -68,7 +68,7 @@ def test_fetch_logs_sets_last_block(w3: Web3, http_url: str, ws_url: str, deploy
     from_block = w3.eth.block_number
     receipt = send_tx(w3, grid.functions.rentCell(1, 1, 0xFF0000), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     assert watcher.store.last_block is None
     for event, block, log_index in watcher.fetch_logs(from_block):
         watcher.store.apply(event, block, log_index)
@@ -76,7 +76,7 @@ def test_fetch_logs_sets_last_block(w3: Web3, http_url: str, ws_url: str, deploy
 
 
 def test_fetch_logs_empty_does_not_change_last_block(w3: Web3, http_url: str, ws_url: str, deployed_contracts: ForgeDeployment) -> None:
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     watcher.store._last_block = 5
     for event, block, log_index in watcher.fetch_logs(w3.eth.block_number):
         watcher.store.apply(event, block, log_index)
@@ -94,7 +94,7 @@ async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deploye
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(3, 4, 0x112233), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     for event, block, log_index in watcher.fetch_logs(from_block):
         watcher.store.apply(event, block, log_index)
 
@@ -102,7 +102,7 @@ async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deploye
     await watcher.store.save_snapshot(snap_path)
 
     cell_id = 4 * 1000 + 3
-    watcher2 = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher2 = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     assert watcher2.store.get(cell_id) is None
     assert watcher2.store.last_block is None
 
@@ -112,7 +112,7 @@ async def test_snapshot_round_trip(w3: Web3, http_url: str, ws_url: str, deploye
 
 
 async def test_save_snapshot_raises_without_last_block(http_url: str, ws_url: str, deployed_contracts: ForgeDeployment, tmp_path: Path) -> None:
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     with pytest.raises(ValueError):
         await watcher.store.save_snapshot(tmp_path / "snap.json")
 
@@ -134,7 +134,7 @@ async def test_watch_catches_up_from_loaded_snapshot(
     from_block = w3.eth.block_number
     send_tx(w3, grid.functions.rentCell(1, 1, 0xFF0000), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     for event, block, log_index in watcher.fetch_logs(from_block):
         watcher.store.apply(event, block, log_index)
     snap_path = tmp_path / "snap.json"
@@ -142,7 +142,7 @@ async def test_watch_catches_up_from_loaded_snapshot(
 
     send_tx(w3, grid.functions.rentCell(2, 2, 0x00FF00), _DEPLOYER_KEY)
 
-    watcher2 = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher2 = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     watcher2.store.load_snapshot(snap_path)
     watch_task = asyncio.create_task(watcher2.watch())
 
@@ -186,7 +186,7 @@ async def test_watch_reconnects_after_disconnect(w3: Web3, http_url: str, ws_url
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
     send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price * 2), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     watch_task = asyncio.create_task(watcher.watch())
 
     for _ in range(20):
@@ -269,7 +269,7 @@ async def test_watch_resubscribes_before_reconnect_backfill(
         async def __aexit__(self, *_args: object) -> None:
             state["subscription_active"] = False
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     watcher._decode_log = lambda log: CellColorUpdated(cell_id=log["cell_id"], renter="0xabc", color=0x0000FF)  # type: ignore[method-assign]
 
     def fetch_logs(_from_block: int) -> list:
@@ -326,7 +326,7 @@ async def test_watch_backfills_from_start_block_on_cold_start(
         async def __aexit__(self, *_args: object) -> None:
             pass
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts, start_block=50)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts, start_block=50)
     watcher._decode_log = lambda log: CellColorUpdated(cell_id=log["cell_id"], renter="0xabc", color=0x0000FF)  # type: ignore[method-assign]
 
     def fetch_logs(from_block: int) -> list:
@@ -380,7 +380,7 @@ async def test_watch_backfills_from_last_block_on_reconnect(
         async def __aexit__(self, *_args: object) -> None:
             pass
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts, start_block=50)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts, start_block=50)
     watcher.store._last_block = 100
     watcher._decode_log = lambda log: CellColorUpdated(cell_id=log["cell_id"], renter="0xabc", color=0x0000FF)  # type: ignore[method-assign]
 
@@ -445,7 +445,7 @@ async def test_watch_fetch_logs_called_via_to_thread(
         if callable(func):
             return func(*args, **kwargs)  # type: ignore[operator]
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     monkeypatch.setattr(watcher_module, "AsyncWeb3", FakeAsyncWeb3)
     monkeypatch.setattr(watcher, "fetch_logs", fake_fetch_logs)
     monkeypatch.setattr(watcher_module.asyncio, "to_thread", fake_to_thread)
@@ -471,7 +471,7 @@ async def test_watch_populates_store(w3: Web3, http_url: str, ws_url: str, deplo
     send_tx(w3, faucet.functions.claim(), _DEPLOYER_KEY)
     send_tx(w3, token.functions.approve(deployed_contracts.grid, deployed_contracts.rent_price), _DEPLOYER_KEY)
 
-    watcher = Watcher(http_url=http_url, ws_url=ws_url, deployment=deployed_contracts)
+    watcher = Watcher(http_url=http_url, ws_url=ws_url, contracts=deployed_contracts)
     watch_task = asyncio.create_task(watcher.watch())
 
     await asyncio.sleep(0.5)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repo-local development helpers for watcher workflows."""

--- a/tools/forge_deploy.py
+++ b/tools/forge_deploy.py
@@ -28,7 +28,7 @@ def contracts_repo_root() -> Path:
     if override:
         root = Path(override).expanduser().resolve()
     else:
-        root = Path(__file__).resolve().parents[3] / "polyplace-contracts"
+        root = Path(__file__).resolve().parents[2] / "polyplace-contracts"
 
     if not root.is_dir():
         raise RuntimeError(

--- a/tools/forge_deploy.py
+++ b/tools/forge_deploy.py
@@ -9,11 +9,11 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from polyplace_contracts.deploy import Deployment
+from polyplace_watcher.config import ContractsConfig
 
 
-@dataclass
-class ForgeDeployment(Deployment):
+@dataclass(frozen=True)
+class ForgeDeployment(ContractsConfig):
     chain_id: int
     deployer: str
     initial_supply: int

--- a/tools/forge_deploy.py
+++ b/tools/forge_deploy.py
@@ -22,6 +22,10 @@ class ForgeDeployment(ContractsConfig):
     rent_price: int
     rent_duration: int
 
+    @classmethod
+    def from_env(cls) -> "ForgeDeployment":
+        raise RuntimeError("ForgeDeployment cannot be constructed from env; use load_forge_deployment().")
+
 
 def contracts_repo_root() -> Path:
     override = os.environ.get("POLYPLACE_CONTRACTS_REPO")
@@ -33,6 +37,7 @@ def contracts_repo_root() -> Path:
     if not root.is_dir():
         raise RuntimeError(
             "Cannot find sibling polyplace-contracts repo. "
+            f"Tried: {root}. "
             "Set POLYPLACE_CONTRACTS_REPO to the repo root if it lives elsewhere."
         )
 
@@ -113,9 +118,11 @@ def deploy_via_forge(
     if not forge_output_path.is_file():
         raise RuntimeError(f"Forge deploy did not write manifest: {forge_output_path}")
 
-    output_path.write_text(forge_output_path.read_text())
-
-    return load_forge_deployment(output_path)
+    try:
+        output_path.write_text(forge_output_path.read_text())
+        return load_forge_deployment(output_path)
+    finally:
+        forge_output_path.unlink(missing_ok=True)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/tools/forge_deploy.py
+++ b/tools/forge_deploy.py
@@ -74,13 +74,14 @@ def deploy_via_forge(
     contracts_root = Path(repo_root).resolve() if repo_root is not None else contracts_repo_root()
     output_path = Path(manifest_path).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    forge_output_dir = contracts_root / ".forge-manifests"
+    relative_forge_output_path = Path(".forge-manifests") / f"{output_path.stem}-{uuid4().hex}.json"
+    forge_output_dir = contracts_root / relative_forge_output_path.parent
     forge_output_dir.mkdir(parents=True, exist_ok=True)
-    forge_output_path = forge_output_dir / f"{output_path.stem}-{uuid4().hex}.json"
+    forge_output_path = contracts_root / relative_forge_output_path
 
     env = os.environ.copy()
     env["PRIVATE_KEY"] = private_key
-    env["POLYPLACE_DEPLOYMENT_MANIFEST_PATH"] = str(forge_output_path)
+    env["POLYPLACE_DEPLOYMENT_MANIFEST_PATH"] = relative_forge_output_path.as_posix()
     if claim_amount is not None:
         env["POLYPLACE_DEPLOY_CLAIM_AMOUNT"] = str(claim_amount)
     if cooldown is not None:


### PR DESCRIPTION
## Summary
- replace the watcher-side Python deployment path with a thin helper that shells out to the sibling polyplace-contracts repo and consumes the Forge deployment manifest
- switch chain-backed pytest fixtures to a session-scoped Forge deploy plus anvil_snapshot/anvil_revert for per-test isolation
- update local dev docs and just recipes so deploy-local uses the same Forge flow as real deployments

## Dependency
- depends on https://github.com/josh-gree/polyplace-contracts/pull/1

## Verification
- uv run pytest tests/test_contracts.py tests/test_e2e.py tests/test_watcher.py -q
