### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+      POLYPLACE_CONTRACTS_REPO: ${{ github.workspace }}/polyplace-contracts
+    steps:
+      - name: Checkout watcher
+        uses: actions/checkout@v4
+        with:
+          path: polyplace-watcher
+
+      - name: Checkout polyplace-contracts
+        uses: actions/checkout@v4
+        with:
+          repository: josh-gree/polyplace-contracts
+          ref: main
+          path: polyplace-contracts
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: polyplace-watcher/uv.lock
+
+      - name: uv sync --frozen
+        working-directory: polyplace-watcher
+        run: uv sync --frozen
+
+      - name: uv run pytest
+        working-directory: polyplace-watcher
+        run: uv run pytest
+
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ If the contracts repo is not present as a sibling, set
 The generated `.local/deployment.json` and `.local/watcher.env` are local
 runtime state and are ignored by git.
 
+## Continuous Integration
+
+GitHub Actions runs on every push to `main` and on every pull request. The
+workflow lives at `.github/workflows/ci.yml` and has two jobs:
+
+- `test` checks out this repo and `polyplace-contracts` as siblings, installs
+  Foundry (pinned to `stable`) and `uv`, then runs `uv sync --frozen` and
+  `uv run pytest`. The pytest suite spawns a local Anvil and deploys contracts
+  via `forge script`, so both Foundry and the contracts repo are required.
+- `docker-build` builds the production `Dockerfile` with Buildx and a GHA
+  layer cache. The image is not pushed.
+
+Local equivalents:
+
+```sh
+uv sync --frozen
+uv run pytest        # needs `anvil` on PATH and ../polyplace-contracts checked out
+podman build .
+```
+
 ## Logging
 
 The service emits structured JSON logs to stdout and `logs/polyplace-watcher.log`.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two jobs (`test`, `docker-build`) running on push to `main`, on every PR, and via `workflow_dispatch`.
- The `test` job checks out `polyplace-contracts` as a sibling, installs Foundry (`stable`) and `uv`, then runs `uv sync --frozen` and `uv run pytest`. The pytest suite spawns `anvil` and shells out to `forge script`, so both Foundry and the sibling contracts repo are required.
- The `docker-build` job builds the production `Dockerfile` with Buildx and a GHA layer cache. The image is not pushed — registry push belongs to the Fly.io CD ticket (#5).
- Adds a "Continuous Integration" section to `README.md` documenting the workflow and the local equivalents (`uv sync --frozen`, `uv run pytest`, `podman build .`).

Implements the plan from #4.

## Acceptance criteria mapping
- [x] CI runs on push and pull request — `on.push` (main) + `on.pull_request`.
- [x] CI runs `uv sync --frozen` — `test` job.
- [x] CI runs `uv run pytest` — `test` job (with Foundry + sibling contracts wired in).
- [x] CI builds the Docker image — `docker-build` job.
- [x] README documents the expected local commands — new "Continuous Integration" section.

## Test plan
- [ ] PR run: confirm both `test` and `docker-build` jobs go green.
- [ ] After merge: confirm the `push`-to-`main` trigger fires and the same two jobs go green.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)