### PR TITLE
ci: add Fly.io deploy workflow with smoke checks and auto-rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,89 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-watcher
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      WATCHER_HOST: polyplace-watcher.fly.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        id: deploy
+        run: flyctl deploy --remote-only
+
+      - name: Smoke checks
+        id: smoke
+        run: |
+          set -euo pipefail
+
+          echo "::group::GET /health"
+          health=$(mktemp)
+          curl --fail \
+               --silent \
+               --show-error \
+               --max-time 10 \
+               --retry 10 \
+               --retry-delay 5 \
+               --retry-connrefused \
+               --retry-all-errors \
+               -o "$health" \
+               "https://${WATCHER_HOST}/health"
+          cat "$health"
+          echo
+          jq -e 'has("last_block") and has("last_log_index")' "$health" > /dev/null
+          echo "::endgroup::"
+
+          echo "::group::GET /grid"
+          grid=$(mktemp)
+          headers=$(mktemp)
+          curl --fail \
+               --silent \
+               --show-error \
+               --max-time 30 \
+               --retry 5 \
+               --retry-delay 5 \
+               --retry-all-errors \
+               -D "$headers" \
+               -o "$grid" \
+               "https://${WATCHER_HOST}/grid"
+          size=$(stat -c%s "$grid")
+          echo "grid bytes: $size"
+          if [ "$size" -le 0 ]; then
+            echo "::error::/grid returned empty body"
+            exit 1
+          fi
+          if ! grep -qi '^content-type:.*application/octet-stream' "$headers"; then
+            echo "::error::/grid returned wrong content-type"
+            grep -i '^content-type' "$headers" || true
+            exit 1
+          fi
+          echo "::endgroup::"
+
+      - name: Rollback on smoke failure
+        if: failure() && steps.deploy.outcome == 'success' && steps.smoke.outcome == 'failure'
+        run: |
+          echo "::warning::Smoke checks failed after a successful deploy — rolling back to the previous release"
+          flyctl releases rollback -y

--- a/README.md
+++ b/README.md
@@ -67,6 +67,62 @@ uv run pytest        # needs `anvil` on PATH and ../polyplace-contracts checked 
 podman build .
 ```
 
+## Continuous Deployment
+
+Merges to `main` are deployed to Fly.io automatically. The workflow lives at
+`.github/workflows/deploy.yml` and is triggered via `workflow_run` after the
+`CI` workflow finishes successfully on `main`, so a red CI run never produces
+a deploy. It can also be run manually via `workflow_dispatch`.
+
+The `deploy` job:
+
+1. Checks out the exact SHA that CI tested.
+2. Runs `flyctl deploy --remote-only`, which builds the image on Fly's remote
+   builder using this repo's `Dockerfile` and `fly.toml`.
+3. Hits `https://polyplace-watcher.fly.dev/health` and `/grid` as smoke
+   checks. `/health` must return JSON containing `last_block` and
+   `last_log_index` keys (values may be `null` immediately after a fresh
+   deploy, before backfill catches up). `/grid` must return
+   `application/octet-stream` with a non-empty body.
+4. If the deploy step succeeded but the smoke checks failed, the workflow
+   runs `flyctl releases rollback -y` to revert to the previous release. The
+   job still fails so the alert fires; the rollback just shrinks the window
+   of brokenness.
+
+Concurrency is set to `deploy-watcher` with `cancel-in-progress: false`, so
+deploys queue rather than cancel each other mid-flight.
+
+### Caveats of auto-rollback
+
+`flyctl releases rollback` reverts the *image*, not the volume. If a bad
+release wrote a corrupted `snapshot.json`, the rolled-back binary will load
+the same bad snapshot. Manual remediation (delete the snapshot or restore a
+known-good copy) is still required in that case. None of the current code
+paths overwrite the snapshot in a way that would corrupt it on startup, but
+worth knowing.
+
+### Secrets
+
+GitHub Actions only needs one secret:
+
+- `FLY_API_TOKEN` — a deploy-scoped Fly token. Mint with
+  `fly tokens create deploy --expiry 8760h` and store under
+  *Settings → Secrets and variables → Actions*. Rotate by minting a new
+  token and replacing the secret; the old token can be revoked with
+  `fly tokens revoke <id>` (look up the id with `fly tokens list`).
+
+All runtime secrets live in Fly, **not** in GitHub. They are managed with
+`fly secrets set` / `fly secrets list` and are never referenced by the
+workflow. The watcher reads at startup:
+
+- `WEB3_HTTP_URL` — JSON-RPC HTTP endpoint for historical backfill.
+- `WEB3_WS_URL` — JSON-RPC WebSocket endpoint for live log subscription.
+- `START_BLOCK` — block height to start indexing from.
+- `GRID_ADDRESS` — deployed `PlaceGrid` contract address.
+
+Public, non-sensitive runtime config (`SNAPSHOT_PATH`, `CORS_ORIGINS`) is
+kept in `fly.toml` under `[env]` and is checked into the repo.
+
 ## Logging
 
 The service emits structured JSON logs to stdout and `logs/polyplace-watcher.log`.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`. Triggered via `workflow_run` after the `CI` workflow finishes successfully on `main`, plus `workflow_dispatch` for manual deploys. A red CI run never produces a deploy.
- Job runs `flyctl deploy --remote-only` (Fly's remote builder uses this repo's `Dockerfile` + `fly.toml`), then smoke-tests the live service.
- Smoke checks: `/health` must return JSON with `last_block` and `last_log_index` keys (values may be `null` immediately post-deploy, before backfill catches up); `/grid` must return `application/octet-stream` with a non-empty body. Both retry with backoff to ride out the brief machine-restart window of a single-machine rolling deploy.
- If the deploy step succeeded but the smoke step failed, the workflow runs `flyctl releases rollback -y`. The job still fails so the alert fires — the rollback just shrinks the bad-release window. Image-only rollback caveats (volume state untouched) are called out in the README.
- Concurrency: `deploy-watcher` group with `cancel-in-progress: false`, so deploys queue rather than cancel each other mid-flight.
- README gains a "Continuous Deployment" section documenting the workflow, the auto-rollback caveat, the `FLY_API_TOKEN` mint/rotate flow, and the runtime-secrets list (kept in Fly, not GitHub).

Closes #5. Builds on #8 (CI workflow) which is already merged.

## Acceptance criteria mapping
- [x] GitHub Actions deploys to Fly.io from `main` — `workflow_run` gated on `head_branch == 'main'` and `conclusion == 'success'`.
- [x] Workflow uses `FLY_API_TOKEN` — job-level `env`.
- [x] Runtime secrets remain in Fly, not GitHub — workflow never references them; documented in README.
- [x] Post-deploy smoke check hits `/health` — `curl` + `jq -e 'has("last_block") and has("last_log_index")'`.
- [x] Post-deploy smoke check fetches `/grid` — `curl` + content-type assertion + non-empty body assertion.
- [x] Failure in smoke checks fails the workflow — `set -euo pipefail` + non-zero `curl` / `jq` exits.

## Test plan
- [ ] Confirm this PR's CI run is green (note: the `Deploy` workflow does *not* run on PRs by design — gated on `workflow_run` from CI completing on `main`).
- [ ] After merge, watch the `Deploy` workflow on `main`: confirm `flyctl deploy --remote-only` succeeds and both smoke checks return 200.
- [ ] Manually hit `https://polyplace-watcher.fly.dev/health` and `/grid` post-deploy as a sanity check.
- [ ] (Optional, separate session) trigger a deliberate smoke failure (e.g., temporarily break `/grid` on a branch, deploy via `workflow_dispatch`) to verify the rollback step fires. Skip if you'd rather not exercise rollback against the live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)