### PR TITLE
ci: pin deploy SHA in /health and gate smoke on it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,36 +21,48 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       WATCHER_HOST: polyplace-watcher.fly.dev
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
         id: deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --build-arg GIT_SHA="$DEPLOY_SHA"
 
       - name: Smoke checks
         id: smoke
         run: |
           set -euo pipefail
 
-          echo "::group::GET /health"
+          echo "::group::GET /health (waiting for deploy sha $DEPLOY_SHA)"
           health=$(mktemp)
-          curl --fail \
-               --silent \
-               --show-error \
-               --max-time 10 \
-               --retry 10 \
-               --retry-delay 5 \
-               --retry-connrefused \
-               --retry-all-errors \
-               -o "$health" \
-               "https://${WATCHER_HOST}/health"
+          deadline=$((SECONDS + 120))
+          actual="(none)"
+          while [ $SECONDS -lt $deadline ]; do
+            if curl --fail --silent --show-error --max-time 10 \
+                    -o "$health" "https://${WATCHER_HOST}/health" 2>/dev/null; then
+              actual=$(jq -r '.git_sha // "unknown"' "$health" 2>/dev/null || echo "unparseable")
+              if [ "$actual" = "$DEPLOY_SHA" ]; then
+                echo "served sha matches deploy: $actual"
+                break
+              fi
+              echo "served sha is $actual, waiting for $DEPLOY_SHA"
+            else
+              echo "/health not yet reachable, retrying"
+            fi
+            sleep 5
+          done
+          if [ "$actual" != "$DEPLOY_SHA" ]; then
+            echo "::error::/health did not report deploy sha $DEPLOY_SHA within 120s (last seen: $actual)"
+            cat "$health" 2>/dev/null || true
+            exit 1
+          fi
           cat "$health"
           echo
           jq -e 'has("last_block") and has("last_log_index")' "$health" > /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,9 @@ RUN uv sync --frozen --no-install-project
 COPY . .
 RUN uv sync --frozen
 
+# Bake the build-time git SHA into the image so /health and startup logs
+# can report which release is serving. Defaults to "unknown" for local builds.
+ARG GIT_SHA=unknown
+ENV POLYPLACE_GIT_SHA=$GIT_SHA
+
 CMD ["uv", "run", "uvicorn", "polyplace_watcher.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -77,12 +77,17 @@ a deploy. It can also be run manually via `workflow_dispatch`.
 The `deploy` job:
 
 1. Checks out the exact SHA that CI tested.
-2. Runs `flyctl deploy --remote-only`, which builds the image on Fly's remote
-   builder using this repo's `Dockerfile` and `fly.toml`.
-3. Hits `https://polyplace-watcher.fly.dev/health` and `/grid` as smoke
-   checks. `/health` must return JSON containing `last_block` and
-   `last_log_index` keys (values may be `null` immediately after a fresh
-   deploy, before backfill catches up). `/grid` must return
+2. Runs `flyctl deploy --remote-only --build-arg GIT_SHA=<sha>`, which builds
+   the image on Fly's remote builder using this repo's `Dockerfile` and
+   `fly.toml`. The build-arg pins the deploy SHA into the image as the
+   `POLYPLACE_GIT_SHA` env var.
+3. Polls `/health` until the served `git_sha` field equals the SHA we just
+   deployed (120s deadline), then asserts the rest of the response shape.
+   The SHA pin is what makes the smoke meaningful: without it the check
+   could pass against the previous release during the brief window before
+   edge routing fully cuts over. `/health` must also contain `last_block`
+   and `last_log_index` keys (values may be `null` immediately after a
+   fresh deploy, before backfill catches up). `/grid` must return
    `application/octet-stream` with a non-empty body.
 4. If the deploy step succeeded but the smoke checks failed, the workflow
    runs `flyctl releases rollback -y` to revert to the previous release. The

--- a/src/polyplace_watcher/app.py
+++ b/src/polyplace_watcher/app.py
@@ -16,6 +16,8 @@ from polyplace_watcher.watcher import Watcher
 
 logger = logging.getLogger(__name__)
 
+GIT_SHA = os.environ.get("POLYPLACE_GIT_SHA", "unknown")
+
 
 def _watcher_from_env(store: GridStore) -> Watcher:
     config = WatcherConfig.from_env()
@@ -56,6 +58,7 @@ async def _snapshot_loop(store: GridStore, path: Path, interval: int) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configure_logging()
+    logger.info("service_starting", extra={"component": "app", "git_sha": GIT_SHA})
     store = GridStore()
     snapshot_path = Path(os.environ.get("SNAPSHOT_PATH", "snapshot.json"))
     snapshot_interval = int(os.environ.get("SNAPSHOT_INTERVAL", "60"))
@@ -108,9 +111,13 @@ app.add_middleware(
 
 
 @app.get("/health")
-async def get_health(request: Request) -> dict[str, int | None]:
+async def get_health(request: Request) -> dict[str, int | str | None]:
     store: GridStore = request.app.state.store
-    return {"last_block": store.last_block, "last_log_index": store.last_log_index}
+    return {
+        "last_block": store.last_block,
+        "last_log_index": store.last_log_index,
+        "git_sha": GIT_SHA,
+    }
 
 
 @app.get("/grid")


### PR DESCRIPTION
## Summary
- `Dockerfile` now takes a `GIT_SHA` build-arg and bakes it into the image as `POLYPLACE_GIT_SHA`. The `ARG`/`ENV` pair sits *after* the dependency-install layer so cache invalidation only affects the source-copy + project-install layers.
- `/health` returns a new top-level `git_sha` field. The watcher also logs the SHA once at app startup as `service_starting`, so `fly logs` shows which release is running without having to curl `/health`.
- `.github/workflows/deploy.yml` passes `--build-arg GIT_SHA=$DEPLOY_SHA` to `flyctl deploy --remote-only`, and replaces the `/health` smoke with a bash poll loop (120s deadline) that requires the served `git_sha` to equal the SHA we just deployed before the rest of the assertions run. `/grid` smoke is unchanged — once `git_sha` matches, the new release is the one serving.
- README's "Continuous Deployment" section explains the SHA pin and why the smoke needs it.

Default for `POLYPLACE_GIT_SHA` is `"unknown"` (set in `app.py` via `os.environ.get(..., "unknown")` and as the `ARG` default in the Dockerfile), which is what local builds and tests see. The smoke's exact-match check fails on `"unknown"` by construction.

Closes #10. Builds on #9.

## Acceptance criteria mapping
- [x] `/health` includes the build-time git SHA — handler change in `app.py`.
- [x] Image bakes the SHA at build time — `ARG GIT_SHA` + `ENV POLYPLACE_GIT_SHA` in `Dockerfile`.
- [x] `flyctl deploy` passes `${{ github.sha }}` as build-arg — `--build-arg GIT_SHA=$DEPLOY_SHA` in `deploy.yml` (where `DEPLOY_SHA` falls through to `github.event.workflow_run.head_sha || github.sha`).
- [x] CD smoke polls `/health` until the served SHA matches before passing — bash loop with 120s deadline.
- [x] Timeout fails the workflow → rollback fires — non-zero exit + existing rollback step gate.
- [x] README documents the pin — CD section update.

## Test plan
- [ ] PR's CI run (`test` + `docker-build`) green. The `Deploy` workflow doesn't run on PRs by design (gated on `workflow_run` from CI succeeding on `main`).
- [ ] After merge: watch the `Deploy` workflow on `main`. The smoke step should see the served `git_sha` match the merge commit SHA within a few iterations of the poll loop, then proceed to the existing shape + `/grid` checks.
- [ ] Manually `curl https://polyplace-watcher.fly.dev/health` post-deploy, confirm the response includes the new `git_sha` field with the expected commit SHA.
- [ ] (Optional) `fly logs -a polyplace-watcher` and grep for `service_starting` to see the SHA captured on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)